### PR TITLE
Remove safety checker from the t2i model

### DIFF
--- a/aictl/cli/main.py
+++ b/aictl/cli/main.py
@@ -35,7 +35,9 @@ def t2i(args):
     model_type = torch.float32 if is_mac else torch.float16
     pipe = StableDiffusionPipeline.from_pretrained(
         args.model, 
-        torch_dtype=model_type
+        torch_dtype=model_type,
+        safety_checker = None,
+        requires_safety_checker = False
     )
     pipe.scheduler = args.scheduler.from_config(pipe.scheduler.config)
     if is_mac:


### PR DESCRIPTION
Updated t2i model to remove NSFW warning to prevent black image generations.
